### PR TITLE
Add handling style.css and refactor handlers as well

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -8,7 +8,7 @@ import (
 	"mr-metrics/internal/api"
 	"mr-metrics/internal/config"
 	"mr-metrics/internal/db"
-	"mr-metrics/internal/handler"
+	"mr-metrics/internal/handlers"
 	"mr-metrics/internal/service/updater"
 
 	_ "github.com/lib/pq"
@@ -29,10 +29,8 @@ func main() {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
 
-	h := handler.New(store, cfg, gitlabClient)
-
 	u := updater.New(store, gitlabClient, cfg)
 	go u.Start(ctx)
 
-	log.Fatal(h.Start(cfg.Port))
+	log.Fatal(handlers.Start(store, cfg, gitlabClient))
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -5,7 +5,10 @@ import (
 	"mr-metrics/internal/config"
 	"mr-metrics/internal/db"
 	"net/http"
+	"time"
 )
+
+const defaultServerTimeout = 3 * time.Second
 
 func Start(db *db.PostgresStore, cfg *config.Config, client *api.GitLabClient) error {
 	mux := http.NewServeMux()

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"mr-metrics/internal/api"
+	"mr-metrics/internal/config"
+	"mr-metrics/internal/db"
+	"net/http"
+)
+
+func Start(db *db.PostgresStore, cfg *config.Config, client *api.GitLabClient) error {
+	mux := http.NewServeMux()
+
+	stats := NewStatsHandler(db, cfg, client)
+
+	mux.HandleFunc("GET /", stats.handleStatsByDate)
+	mux.HandleFunc("GET /static/style.css", handleStyle)
+
+	server := http.Server{
+		Addr:              ":" + cfg.Port,
+		ReadHeaderTimeout: defaultServerTimeout,
+		Handler:           mux,
+	}
+
+	return server.ListenAndServe()
+}

--- a/internal/handlers/stats.go
+++ b/internal/handlers/stats.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const defaultServerTimeout = 3 * time.Second
-
 type StatsStore interface {
 	GetAggregatedData(projectNames []string) (*model.AggregatedStats, error)
 	GetAggregatedDataForDate(projectNames []string, targetDate time.Time) (*model.AggregatedStats, error)

--- a/internal/handlers/stats.go
+++ b/internal/handlers/stats.go
@@ -1,8 +1,7 @@
-package handler
+package handlers
 
 import (
 	"html/template"
-	"mr-metrics/internal/api"
 	"mr-metrics/internal/config"
 	"mr-metrics/internal/model"
 	"net/http"
@@ -15,34 +14,24 @@ type StatsStore interface {
 	GetAggregatedData(projectNames []string) (*model.AggregatedStats, error)
 	GetAggregatedDataForDate(projectNames []string, targetDate time.Time) (*model.AggregatedStats, error)
 }
+
+type StatsClient interface {
+	GetMergedMRCounts(projectName string) (map[string]int, int, error)
+}
 type StatsHandler struct {
 	store  StatsStore
+	client StatsClient
 	cfg    *config.Config
-	client *api.GitLabClient
 	tmpl   *template.Template
 }
 
-func New(store StatsStore, cfg *config.Config, client *api.GitLabClient) *StatsHandler {
+func NewStatsHandler(store StatsStore, cfg *config.Config, client StatsClient) *StatsHandler {
 	return &StatsHandler{
 		store:  store,
 		cfg:    cfg,
 		client: client,
 		tmpl:   template.Must(template.ParseFiles("internal/web/templates/index.html")),
 	}
-}
-
-func (h *StatsHandler) Start(port string) error {
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("GET /", h.handleStatsByDate)
-
-	server := http.Server{
-		Addr:              ":" + port,
-		ReadHeaderTimeout: defaultServerTimeout,
-		Handler:           mux,
-	}
-
-	return server.ListenAndServe()
 }
 
 func (h *StatsHandler) handleStats(w http.ResponseWriter, _ *http.Request) {

--- a/internal/handlers/style.go
+++ b/internal/handlers/style.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+func handleStyle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+
+	file, err := os.Open("./internal/web/style.css")
+	if err != nil {
+		http.Error(w, "Failed to open file", http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	_, err = io.Copy(w, file)
+	if err != nil {
+		http.Error(w, "Failed to copy file", http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/web/style.css
+++ b/internal/web/style.css
@@ -1,0 +1,12 @@
+#dev-th {
+    padding-left: 0;
+    text-align: left;
+}
+
+.project-th {
+    padding-right: 1.5em;
+}
+
+.dev-td {
+    padding-right: 1.5em;
+}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -2,23 +2,24 @@
 <html lang="en">
 <head>
     <title>Merged requests</title>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <h1>Merged requests
-{{ if .DateString }}
+    {{ if .DateString }}
     up to {{ .DateString }}
-{{ end }}
+    {{ end }}
 </h1>
 <table>
     <tr>
-        <th style="text-align: left;padding-left: 0">Developer</th>
+        <th id="dev-th">Developer</th>
         {{range .Projects}}
-        <th style="padding-right: 1.5em">{{.}}</th>
+        <th class="project-th">{{.}}</th>
         {{end}}
     </tr>
     {{range $dev, $counts := .Developers}}
     <tr>
-        <td style="padding-right: 1.5em; ">{{$dev}}</td>
+        <td class="dev-td">{{$dev}}</td>
         {{range $project := $.Projects}}
         <td>{{index $counts $project}}</td>
         {{end}}


### PR DESCRIPTION
Now we provide whole postgres store and gitlab client structs to handlers.Start() function, but isolate behaviour with interfaces used for each handler