### PR TITLE
Add total amount of merged requests per repository

### DIFF
--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -8,6 +8,8 @@ type AggregatedStats struct {
 	DateString string
 	// Total amount of merged requests per developer
 	DevTotals map[string]int
+	// Total amount of merged requests per repo
+	RepoTotals map[string]int
 }
 
 type ProjectMRCounts struct {

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -23,5 +23,13 @@ func TemplateExec(w http.ResponseWriter, t *template.Template, data any) error {
 }
 
 func TemplateStats() *template.Template {
-	return templateFrom(nil, "stats")
+	return templateFrom(template.FuncMap{"sum": mapSumFunc}, "stats")
+}
+
+func mapSumFunc(m map[string]int) int {
+	var sum int
+	for _, v := range m {
+		sum += v
+	}
+	return sum
 }

--- a/internal/web/templates/stats.gohtml
+++ b/internal/web/templates/stats.gohtml
@@ -10,7 +10,7 @@
             {{range .Projects}}
                 <th class="project-th">{{.}}</th>
             {{end}}
-            <th>Total</th>
+            <th>TOTAL</th>
         </tr>
         {{range $dev, $counts := .Developers}}
             <tr>
@@ -21,5 +21,12 @@
                 <td>{{index $.DevTotals $dev}}</td>
             </tr>
         {{end}}
+        <tr>
+            <td><strong>TOTAL</strong></td>
+            {{range $project := $.Projects}}
+                <td>{{index $.RepoTotals $project}}</td>
+            {{end}}
+            <td>{{sum $.RepoTotals}}</td>
+        </tr>
     </table>
 {{end}}


### PR DESCRIPTION
With sql query we select/create a fake developer with name 'TOTAL' that represents a total amount of merged requests per repo. Turns out we get a TOTAL x TOTAL cell for free

Closes: #36 
Closes: #37 
Closes: #38 